### PR TITLE
[post]: 게시판 엔티티 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
@@ -34,7 +34,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+//    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/gospace/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/gospace/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.example.gospace.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing // createdAt, updateAt 세팅
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/example/gospace/post/controller/PostController.java
+++ b/src/main/java/com/example/gospace/post/controller/PostController.java
@@ -1,0 +1,4 @@
+package com.example.gospace.post.controller;
+
+public class PostController {
+}

--- a/src/main/java/com/example/gospace/post/entity/Category.java
+++ b/src/main/java/com/example/gospace/post/entity/Category.java
@@ -1,0 +1,7 @@
+package com.example.gospace.post.entity;
+
+public enum Category {
+    STUDY_TIPS, // 공부법
+    CSAT,       // 수능
+    MENTAL      // 멘탈
+}

--- a/src/main/java/com/example/gospace/post/entity/Post.java
+++ b/src/main/java/com/example/gospace/post/entity/Post.java
@@ -1,16 +1,72 @@
 package com.example.gospace.post.entity;
 
-
-import jakarta.persistence.Access;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
 
+@EntityListeners(AuditingEntityListener.class)
+@Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "posts")
+
 public class Post {
-//    @Id
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category",nullable = false)
+    private Category category;
+
+    //익명 여부 User 엔티티 구성시 후보키 가능할듯 + Boolean(x) -> boolean(o) 사용
+    @Column(name = "is_anon", nullable = false)
+    private boolean isAnon;
+
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    //길이 제한 없앨 경우 @Lob 사용 및 columnDefinition = "TEXT" 형태
+    @Column(name = "content", nullable = false, length = 500)
+    private String content;
+
+//    User 엔티티로 옮겨야 하는 코드
+//    @Column(name = "student_card_url", nullable = false, length = 255)
+//    private String studentCardUrl;
+
+
+    @CreatedDate
+    @Column(name = "created_at",nullable = false,updatable = false)
+    private LocalDateTime createdAt;
+
+
+    @LastModifiedDate
+    @Column(name = "updated_at",nullable = false)
+    private LocalDateTime updatedAt;
+
+//    FK -> User(id)
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+//    private User user;
+
+//    FK -> School(id)
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "school_id", nullable = false)
+//    private School school;
+
+//    익명 닉네임 -> 대체 키 가능?
+//    @Column(name = "anno_key", length = 50, unique = true)
+//    private String annoKey;
 
 }

--- a/src/main/java/com/example/gospace/post/repository/PostRepository.java
+++ b/src/main/java/com/example/gospace/post/repository/PostRepository.java
@@ -1,0 +1,15 @@
+package com.example.gospace.post.repository;
+
+import com.example.gospace.post.entity.Category;
+import com.example.gospace.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    //제목 검색 -> 부분 일치로 검색 가능
+    List<Post> findByTitleContaining(String keyword);
+
+    //카테고리별 조회
+    List<Post> findByCategory(Category category);
+}

--- a/src/main/java/com/example/gospace/post/service/PostService.java
+++ b/src/main/java/com/example/gospace/post/service/PostService.java
@@ -1,0 +1,4 @@
+package com.example.gospace.post.service;
+
+public class PostService {
+}

--- a/src/main/resources/application-h2.yml
+++ b/src/main/resources/application-h2.yml
@@ -1,0 +1,13 @@
+spring:
+    jpa:
+        show-sql: true
+        properties:
+            hibernate:
+                format_sql: true
+        defer-datasource-initialization: true
+    datasource:
+        url: jdbc:h2:mem:testdb
+        username: sa
+    h2:
+        console:
+            enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+    jpa:
+        hibernate:
+            ddl-auto: update
+        properties:
+            hibernate:
+                format_sql: true
+    profiles:
+        active: h2 #일단 기본 h2 -> mysql 변경 가능

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,5 @@
+INSERT INTO posts (category, is_anon, title, content, created_at, updated_at)
+VALUES ('STUDY_TIPS', FALSE, '첫 번째 글', '이것은 테스트 본문입니다.', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO posts (category, is_anon, title, content, created_at, updated_at)
+VALUES ('MENTAL', TRUE, '익명 글', '익명 작성자의 테스트 글입니다.', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);


### PR DESCRIPTION
## 관련 이슈

> #7
 

## 작업 내용
1. 게시판 엔티티 구성
2. 게시판 레포지토리 기본 구성
3. h2 DB 테스트

## ETC
h2 DB 테스트 한다고 Spring_Security 부분 비활성화 했습니다. 참고 부탁드립니다.

추후 User 엔티티 생성, School 엔티티 생성시 관계 맺은 후 h2-DB 추가 테스트 진행하겠습니다.

게시판 content(내용) 컬럼 부분 Lob(길이제한 x)과 length 길이 제한 두 부분으로 나눴습니다. 선택 시 바로 수정 가능합니다. 기본은 길이제한 500자로 했습니다.
<img width="1127" height="525" alt="image" src="https://github.com/user-attachments/assets/b269e284-577b-4e0d-9db1-95f21d56f78c" />
