### PR TITLE
[Common] 공통 예외처리 핸들러 구현

### DIFF
--- a/src/main/java/com/example/gospace/archive/controller/ArchiveController.java
+++ b/src/main/java/com/example/gospace/archive/controller/ArchiveController.java
@@ -1,9 +1,19 @@
 package com.example.gospace.archive.controller;
 
 
+import com.example.gospace.archive.dto.ArchiveDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequestMapping("api/v1/archives")
 @RestController
 public class ArchiveController {
 
+    @PostMapping()
+    private ResponseEntity<?> create(@RequestBody ArchiveDto archiveDto) {
+        return ResponseEntity.ok("test");
+    }
 }

--- a/src/main/java/com/example/gospace/common/error/ErrorCode.java
+++ b/src/main/java/com/example/gospace/common/error/ErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.gospace.common.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    //common
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "잘못된 HTTP 메서드를 호출했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러가 발생했습니다."),
+    MESSAGE_BODY_UNREADABLE(HttpStatus.BAD_REQUEST, "COMMON400", "요청 본문을 읽을 수 없습니다."),
+    INVALID_ENUM_FORMAT(HttpStatus.BAD_REQUEST, "COMMON400", "'%s'은(는) 유효한 %s 값이 아닙니다.")
+
+    ;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(final HttpStatus status, final String code, final String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/gospace/common/error/ErrorCode.java
+++ b/src/main/java/com/example/gospace/common/error/ErrorCode.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     //common
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
-
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "잘못된 HTTP 메서드를 호출했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러가 발생했습니다."),

--- a/src/main/java/com/example/gospace/common/error/ErrorResponse.java
+++ b/src/main/java/com/example/gospace/common/error/ErrorResponse.java
@@ -1,0 +1,38 @@
+package com.example.gospace.common.error;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse<T> {
+    private String code;
+    private String message;
+    private T data;
+
+    public ErrorResponse(final ErrorCode code, final T data) {
+        this.code = code.getCode();
+        this.message = code.getMessage();
+        this.data = data;
+    }
+
+    public ErrorResponse(final ErrorCode code, final String message) {
+        this.code = code.getCode();
+        this.message = message;
+    }
+
+    public static <T> ErrorResponse<T> of(final ErrorCode code, final T data) {
+        return new ErrorResponse<>(code, data);
+    }
+
+    public static ErrorResponse<Void> of(final ErrorCode code, final String message) {
+        return new ErrorResponse<>(code, message);
+    }
+
+    public static ErrorResponse<Void> of(final ErrorCode code) {
+        return new ErrorResponse<>(code, null);
+    }
+}

--- a/src/main/java/com/example/gospace/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/gospace/common/error/GlobalExceptionHandler.java
@@ -1,12 +1,14 @@
 package com.example.gospace.common.error;
+
 import static com.example.gospace.common.error.ErrorCode.INVALID_ENUM_FORMAT;
 import static com.example.gospace.common.error.ErrorCode.MESSAGE_BODY_UNREADABLE;
 
 import com.example.gospace.common.exception.AuthException;
 import com.example.gospace.common.exception.BusinessException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import java.util.HashMap;
 import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -14,101 +16,103 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-
-import lombok.extern.slf4j.Slf4j;
-
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
 
+    // 지원하지 않는 HTTP method 호출할 경우 발생하는 예외 처리
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleHttpRequestMethodNotSupported(
+        HttpRequestMethodNotSupportedException e) {
+        log.error("HttpRequestMethodNotSupportedException", e);
+        return createErrorResponseEntity(ErrorCode.METHOD_NOT_ALLOWED,
+            ErrorCode.METHOD_NOT_ALLOWED.getMessage());
+    }
 
-        // 지원하지 않는 HTTP method 호출할 경우 발생하는 예외 처리
-        @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-        protected ResponseEntity<ErrorResponse<Void>> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
-            log.error("HttpRequestMethodNotSupportedException", e);
-            return createErrorResponseEntity(ErrorCode.METHOD_NOT_ALLOWED);
+    // @Valid 관련 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse<Map<String, String>>> handleMethodArgumentNotValid(
+        MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException", e);
+
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(
+            error -> errors.put(error.getField(), error.getDefaultMessage()));
+
+        return createErrorResponseEntity(ErrorCode.BAD_REQUEST, errors);
+    }
+
+    // Enum 관련 예외
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse<Void>> handleHttpMessageNotReadable(
+        HttpMessageNotReadableException e) {
+        if (isEnumBindingError(e)) {
+            return handleEnumBindingError((InvalidFormatException) e.getCause());
         }
+        return createErrorResponseEntity(MESSAGE_BODY_UNREADABLE,
+            MESSAGE_BODY_UNREADABLE.getMessage());
+    }
 
-        // @Valid 관련 예외 처리
-        @ExceptionHandler(MethodArgumentNotValidException.class)
-        protected ResponseEntity<ErrorResponse<Map<String, String>>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
-            log.error("MethodArgumentNotValidException", e);
+    @ExceptionHandler(AuthException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleAuthException(AuthException e) {
+        log.error("AuthException", e);
+        return createErrorResponseEntity(e.getErrorCode(), e.getMessage());
+    }
 
-            Map<String, String> errors = new HashMap<>();
-            e.getBindingResult().getFieldErrors().forEach(
-                error -> errors.put(error.getField(), error.getDefaultMessage()));
+    // 커스텀 비즈니스 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleBusinessException(BusinessException e) {
+        log.error("BusinessException", e);
+        return createErrorResponseEntity(e.getErrorCode());
+    }
 
-            return createErrorResponseEntity(ErrorCode.BAD_REQUEST, errors);
-        }
+    // IllegalArgumentException 예외 처리
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleIllegalArgumentException(
+        IllegalArgumentException e) {
+        log.error("IllegalArgumentException", e);
+        return createErrorResponseEntity(ErrorCode.BAD_REQUEST, e.getMessage());
+    }
 
-        // Enum 관련 예외
-        @ExceptionHandler(HttpMessageNotReadableException.class)
-        public ResponseEntity<ErrorResponse<Void>> handleHttpMessageNotReadable(
-            HttpMessageNotReadableException e) {
-            if (isEnumBindingError(e)) {
-                return handleEnumBindingError((InvalidFormatException) e.getCause());
-            }
-            return createErrorResponseEntity(MESSAGE_BODY_UNREADABLE, MESSAGE_BODY_UNREADABLE.getMessage());
-        }
+    // 그외 예외 처리
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleExceptionInternal(Exception e) {
+        log.error("Exception", e);
+        return createErrorResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
 
-        @ExceptionHandler(AuthException.class)
-        protected ResponseEntity<ErrorResponse<Void>> handleAuthException(AuthException e) {
-            log.error("AuthException", e);
-            return createErrorResponseEntity(e.getErrorCode(), e.getMessage());
-        }
+    private ResponseEntity<ErrorResponse<Void>> handleEnumBindingError(InvalidFormatException e) {
+        String enumName = e.getTargetType().getSimpleName();
+        String invalidValue = String.valueOf(e.getValue());
+        String message = String.format(INVALID_ENUM_FORMAT.getMessage(), invalidValue, enumName);
+        return createErrorResponseEntity(INVALID_ENUM_FORMAT, message);
+    }
 
-        // 커스텀 비즈니스 예외 처리
-        @ExceptionHandler(BusinessException.class)
-        protected ResponseEntity<ErrorResponse<Void>> handleBusinessException(BusinessException e) {
-            log.error("BusinessException", e);
-            return createErrorResponseEntity(e.getErrorCode());
-        }
+    private ResponseEntity<ErrorResponse<Void>> createErrorResponseEntity(ErrorCode errorCode) {
+        return new ResponseEntity<>(
+            ErrorResponse.of(errorCode),
+            errorCode.getStatus());
+    }
 
-        // IllegalArgumentException 예외 처리
-        @ExceptionHandler(IllegalArgumentException.class)
-        protected ResponseEntity<ErrorResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
-            log.error("IllegalArgumentException", e);
-            return createErrorResponseEntity(ErrorCode.BAD_REQUEST, e.getMessage());
-        }
+    private <T> ResponseEntity<ErrorResponse<T>> createErrorResponseEntity(ErrorCode errorCode,
+        T data) {
+        return new ResponseEntity<>(
+            ErrorResponse.of(errorCode, data),
+            errorCode.getStatus());
+    }
 
-        // 그외 예외 처리
-        @ExceptionHandler(Exception.class)
-        protected ResponseEntity<ErrorResponse<Void>> handleExceptionInternal(Exception e) {
-            log.error("Exception", e);
-            return createErrorResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
+    private ResponseEntity<ErrorResponse<Void>> createErrorResponseEntity(ErrorCode errorCode,
+        String message) {
+        return new ResponseEntity<>(
+            ErrorResponse.of(errorCode, message),
+            errorCode.getStatus());
+    }
 
-        private ResponseEntity<ErrorResponse<Void>> handleEnumBindingError(InvalidFormatException e) {
-            String enumName = e.getTargetType().getSimpleName();
-            String invalidValue = String.valueOf(e.getValue());
-            String message = String.format(INVALID_ENUM_FORMAT.getMessage(), invalidValue, enumName);
-            return createErrorResponseEntity(INVALID_ENUM_FORMAT, message);
-        }
-
-        private ResponseEntity<ErrorResponse<Void>> createErrorResponseEntity(ErrorCode errorCode) {
-            return new ResponseEntity<>(
-                ErrorResponse.of(errorCode),
-                errorCode.getStatus());
-        }
-
-        private <T> ResponseEntity<ErrorResponse<T>> createErrorResponseEntity(ErrorCode errorCode, T data) {
-            return new ResponseEntity<>(
-                ErrorResponse.of(errorCode, data),
-                errorCode.getStatus());
-        }
-
-        private ResponseEntity<ErrorResponse<Void>> createErrorResponseEntity(ErrorCode errorCode, String message) {
-            return new ResponseEntity<>(
-                ErrorResponse.of(errorCode, message),
-                errorCode.getStatus());
-        }
-
-        private boolean isEnumBindingError(HttpMessageNotReadableException e) {
-            return e.getCause() instanceof InvalidFormatException ife
-                && ife.getTargetType().isEnum();
+    private boolean isEnumBindingError(HttpMessageNotReadableException e) {
+        return e.getCause() instanceof InvalidFormatException ife
+            && ife.getTargetType().isEnum();
     }
 
 }

--- a/src/main/java/com/example/gospace/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/gospace/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,114 @@
+package com.example.gospace.common.error;
+import static com.example.gospace.common.error.ErrorCode.INVALID_ENUM_FORMAT;
+import static com.example.gospace.common.error.ErrorCode.MESSAGE_BODY_UNREADABLE;
+
+import com.example.gospace.common.exception.AuthException;
+import com.example.gospace.common.exception.BusinessException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+
+        // 지원하지 않는 HTTP method 호출할 경우 발생하는 예외 처리
+        @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+        protected ResponseEntity<ErrorResponse<Void>> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+            log.error("HttpRequestMethodNotSupportedException", e);
+            return createErrorResponseEntity(ErrorCode.METHOD_NOT_ALLOWED);
+        }
+
+        // @Valid 관련 예외 처리
+        @ExceptionHandler(MethodArgumentNotValidException.class)
+        protected ResponseEntity<ErrorResponse<Map<String, String>>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+            log.error("MethodArgumentNotValidException", e);
+
+            Map<String, String> errors = new HashMap<>();
+            e.getBindingResult().getFieldErrors().forEach(
+                error -> errors.put(error.getField(), error.getDefaultMessage()));
+
+            return createErrorResponseEntity(ErrorCode.BAD_REQUEST, errors);
+        }
+
+        // Enum 관련 예외
+        @ExceptionHandler(HttpMessageNotReadableException.class)
+        public ResponseEntity<ErrorResponse<Void>> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException e) {
+            if (isEnumBindingError(e)) {
+                return handleEnumBindingError((InvalidFormatException) e.getCause());
+            }
+            return createErrorResponseEntity(MESSAGE_BODY_UNREADABLE, MESSAGE_BODY_UNREADABLE.getMessage());
+        }
+
+        @ExceptionHandler(AuthException.class)
+        protected ResponseEntity<ErrorResponse<Void>> handleAuthException(AuthException e) {
+            log.error("AuthException", e);
+            return createErrorResponseEntity(e.getErrorCode(), e.getMessage());
+        }
+
+        // 커스텀 비즈니스 예외 처리
+        @ExceptionHandler(BusinessException.class)
+        protected ResponseEntity<ErrorResponse<Void>> handleBusinessException(BusinessException e) {
+            log.error("BusinessException", e);
+            return createErrorResponseEntity(e.getErrorCode());
+        }
+
+        // IllegalArgumentException 예외 처리
+        @ExceptionHandler(IllegalArgumentException.class)
+        protected ResponseEntity<ErrorResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+            log.error("IllegalArgumentException", e);
+            return createErrorResponseEntity(ErrorCode.BAD_REQUEST, e.getMessage());
+        }
+
+        // 그외 예외 처리
+        @ExceptionHandler(Exception.class)
+        protected ResponseEntity<ErrorResponse<Void>> handleExceptionInternal(Exception e) {
+            log.error("Exception", e);
+            return createErrorResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        private ResponseEntity<ErrorResponse<Void>> handleEnumBindingError(InvalidFormatException e) {
+            String enumName = e.getTargetType().getSimpleName();
+            String invalidValue = String.valueOf(e.getValue());
+            String message = String.format(INVALID_ENUM_FORMAT.getMessage(), invalidValue, enumName);
+            return createErrorResponseEntity(INVALID_ENUM_FORMAT, message);
+        }
+
+        private ResponseEntity<ErrorResponse<Void>> createErrorResponseEntity(ErrorCode errorCode) {
+            return new ResponseEntity<>(
+                ErrorResponse.of(errorCode),
+                errorCode.getStatus());
+        }
+
+        private <T> ResponseEntity<ErrorResponse<T>> createErrorResponseEntity(ErrorCode errorCode, T data) {
+            return new ResponseEntity<>(
+                ErrorResponse.of(errorCode, data),
+                errorCode.getStatus());
+        }
+
+        private ResponseEntity<ErrorResponse<Void>> createErrorResponseEntity(ErrorCode errorCode, String message) {
+            return new ResponseEntity<>(
+                ErrorResponse.of(errorCode, message),
+                errorCode.getStatus());
+        }
+
+        private boolean isEnumBindingError(HttpMessageNotReadableException e) {
+            return e.getCause() instanceof InvalidFormatException ife
+                && ife.getTargetType().isEnum();
+    }
+
+}

--- a/src/main/java/com/example/gospace/common/exception/AuthException.java
+++ b/src/main/java/com/example/gospace/common/exception/AuthException.java
@@ -1,0 +1,18 @@
+package com.example.gospace.common.exception;
+
+
+import com.example.gospace.common.error.ErrorCode;
+
+public class AuthException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public AuthException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/main/java/com/example/gospace/common/exception/BusinessException.java
+++ b/src/main/java/com/example/gospace/common/exception/BusinessException.java
@@ -1,0 +1,23 @@
+package com.example.gospace.common.exception;
+
+
+import com.example.gospace.common.error.ErrorCode;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/example/gospace/common/exception/NotFoundException.java
+++ b/src/main/java/com/example/gospace/common/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.gospace.common.exception;
+
+
+import com.example.gospace.common.error.ErrorCode;
+
+public class NotFoundException extends BusinessException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+    }
+
+}

--- a/src/test/java/com/example/gospace/error/ErrorHandlerTest.java
+++ b/src/test/java/com/example/gospace/error/ErrorHandlerTest.java
@@ -1,0 +1,44 @@
+package com.example.gospace.error;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.gospace.common.error.ErrorCode;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class ErrorHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @BeforeEach
+    void 기초셋팅() {
+        this.mockMvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .addFilters(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))  // 필터 추가
+            .build();
+    }
+
+    @Test
+    void 잘못된_메서드_호출() throws Exception {
+        mockMvc.perform(get("/api/v1/archives"))
+            .andExpect(status().isMethodNotAllowed())
+            .andExpect(jsonPath("$.code").value(ErrorCode.METHOD_NOT_ALLOWED.getCode()))
+            .andExpect(jsonPath("$.message").value(ErrorCode.METHOD_NOT_ALLOWED.getMessage()));
+    }
+}


### PR DESCRIPTION
## 관련 이슈

> #13 

## 작업 내용

1. ErrorCode 정의
ErrorCode는 에러 유형과 메시지를 포함하는 enum입니다. 각 에러는 다음과 같은 정보를 제공합니다:

status: HTTP 상태 코드 (예: 405)
code: 내부 서비스 에러 코드 (예: "COMMON405")
message: 사용자 친화적 에러 메시지 (예: "잘못된 HTTP 메서드를 호출했습니다.")

작성 위치: 각 도메인별 에러 코드는 common -> error -> ErrorCode에 정의합니다.
예시:
```java
// example)
INVALID_ENUM_FORMAT(HttpStatus.BAD_REQUEST, "COMMON400", "'%s'은(는) 유효한 %s 값이 아닙니다.");
```
---

2. ErrorResponse 사용 목적
ErrorResponse는 클라이언트에게 JSON 형태로 에러 정보를 전달하기 위해 사용됩니다. 포함되는 정보:

code: 서비스 에러 코드
message: 사용자에게 보여줄 에러 메시지
data: 추가 데이터 (옵션, 필요 시 사용)

에시:
```java
                location = locationRepository.findById(request.locationId())
                                .orElseThrow(() -> new NotFoundException(LOCATION_NOT_FOUND));
```

## ETC
> https://mangkyu.tistory.com/205 